### PR TITLE
Gts210

### DIFF
--- a/ANDRAX-OS/NeoTermBridge/proguard-rules.pro
+++ b/ANDRAX-OS/NeoTermBridge/proguard-rules.pro
@@ -19,3 +19,256 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+--------- beginning of main
+04-07 13:29:40.826  9232  9232 I GetTextFragment: newInstance called
+04-07 13:29:40.826  9232  9232 I GetTextFragment: newInstance called
+04-07 13:29:40.831  9232  9232 D PermissionsManager: [android.permission.INTERNET, android.permission.VIBRATE, android.permission.ACCESS_NETWORK_STATE, android.permission.READ_EXTERNAL_STORAGE, android.permission.WRITE_EXTERNAL_STORAGE]
+04-07 13:29:40.859  9232  9232 W Activity: Can reqeust only one set of permissions at a time
+04-07 13:29:40.861  9232  9232 I MainConfiguration: onStart called
+04-07 13:29:40.864  9232  9232 I MainConfiguration: onResume called
+04-07 13:29:40.865  9232  9232 I MainConfiguration: onResumeFragments called
+04-07 13:29:40.868  9232  9232 I MainConfiguration: arriveOnPage called
+04-07 13:29:40.948  9232  9249 D OpenGLRenderer: HWUI GL Pipeline
+04-07 13:29:40.956  9232  9232 I MainConfiguration: onPause called
+04-07 13:29:41.113  9232  9249 I Adreno  : QUALCOMM build                   : bc01238, I8e5c908169
+04-07 13:29:41.113  9232  9249 I Adreno  : Build Date                       : 12/22/16
+04-07 13:29:41.113  9232  9249 I Adreno  : OpenGL ES Shader Compiler Version: XE031.09.00.03
+04-07 13:29:41.113  9232  9249 I Adreno  : Local Branch                     : mybranch24102081
+04-07 13:29:41.113  9232  9249 I Adreno  : Remote Branch                    : quic/LA.BR.1.3.6.c1_rb1.5
+04-07 13:29:41.113  9232  9249 I Adreno  : Remote Branch                    : NONE
+04-07 13:29:41.113  9232  9249 I Adreno  : Reconstruct Branch               : NOTHING
+04-07 13:29:41.141  9232  9249 I zygote64: android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
+04-07 13:29:41.142  9232  9249 I OpenGLRenderer: Initialized EGL, version 1.4
+04-07 13:29:41.142  9232  9249 D OpenGLRenderer: Swap behavior 2
+04-07 13:29:41.234  9232  9249 D vndksupport: Loading /vendor/lib64/hw/android.hardware.graphics.mapper@2.0-impl.so from current namespace instead of sphal namespace.
+04-07 13:29:42.690  9232  9232 I MainConfiguration: onResume called
+04-07 13:29:42.719  9232  9232 I MainConfiguration: onResumeFragments called
+04-07 13:29:42.719  9232  9232 I MainConfiguration: arriveOnPage called
+04-07 13:29:42.811  9232  9232 W InputMethodManager: Ignoring onBind: cur seq=128, given seq=127
+04-07 13:29:48.289  9232  9232 I MainConfiguration: onPause called
+04-07 13:29:48.840  9232  9237 I zygote64: Do partial code cache collection, code=30KB, data=29KB
+04-07 13:29:48.840  9232  9237 I zygote64: After code cache collection, code=30KB, data=29KB
+04-07 13:29:48.840  9232  9237 I zygote64: Increasing code cache capacity to 128KB
+04-07 13:29:48.851  9232  9232 I RemoteCanvas: Initializing connection to: localhost, port: 1
+04-07 13:29:48.853  9232  9273 I RemoteCanvas: Establishing VNC session to: localhost, port: 5901
+04-07 13:29:48.853  9232  9273 V RfbProto: Connecting to server: localhost at port: 5901
+04-07 13:29:48.856  9232  9232 I InputHandlerGeneric: displayDensity, baseSwipeDist, immersiveSwipeDistance: 2.0 20.0 20.0
+04-07 13:29:48.865  9232  9232 I RemoteCanvasActivity: onResume called.
+04-07 13:29:48.870  9232  9232 I Choreographer: Skipped 31 frames!  The application may be doing too much work on its main thread.
+04-07 13:29:48.953  9232  9273 W System.err: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:29:48.955  9232  9273 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.Socket.connect(Socket.java:616)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.Socket.connect(Socket.java:565)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.Socket.<init>(Socket.java:445)
+04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.Socket.<init>(Socket.java:217)
+04-07 13:29:48.955  9232  9273 W System.err: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
+04-07 13:29:48.955  9232  9273 W System.err: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
+04-07 13:29:48.955  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
+04-07 13:29:48.955  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
+04-07 13:29:48.956  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
+04-07 13:29:48.956  9232  9273 W System.err: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
+04-07 13:29:48.956  9232  9273 W System.err: 	at libcore.io.Linux.connect(Native Method)
+04-07 13:29:48.956  9232  9273 W System.err: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
+04-07 13:29:48.956  9232  9273 W System.err: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
+04-07 13:29:48.956  9232  9273 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
+04-07 13:29:48.956  9232  9273 W System.err: 	... 14 more
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: java.lang.Exception: Connection to VNC server failed with reason: 
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.Socket.connect(Socket.java:616)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.Socket.connect(Socket.java:565)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.Socket.<init>(Socket.java:445)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.Socket.<init>(Socket.java:217)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.Linux.connect(Native Method)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
+04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	... 14 more
+04-07 13:29:48.957  9232  9273 W System.err: java.lang.Exception: Connection to VNC server failed with reason: 
+04-07 13:29:48.957  9232  9273 W System.err: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:29:48.957  9232  9273 W System.err: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:29:48.957  9232  9273 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
+04-07 13:29:48.957  9232  9273 W System.err: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
+04-07 13:29:48.957  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
+04-07 13:29:48.957  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
+04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
+04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
+04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.Socket.connect(Socket.java:616)
+04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.Socket.connect(Socket.java:565)
+04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.Socket.<init>(Socket.java:445)
+04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.Socket.<init>(Socket.java:217)
+04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
+04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
+04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
+04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
+04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
+04-07 13:29:48.958  9232  9273 W System.err: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
+04-07 13:29:48.958  9232  9273 W System.err: 	at libcore.io.Linux.connect(Native Method)
+04-07 13:29:48.958  9232  9273 W System.err: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
+04-07 13:29:48.958  9232  9273 W System.err: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
+04-07 13:29:48.958  9232  9273 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
+04-07 13:29:48.958  9232  9273 W System.err: 	... 14 more
+04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:475)
+04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
+04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
+04-07 13:29:48.959  9232  9273 V RfbProto: RFB socket closed
+04-07 13:29:48.959  9232  9273 V RemoteCanvas: Cleaning up resources
+04-07 13:29:49.412  9232  9232 D RemoteCanvas: onCreateInputConnection called
+04-07 13:29:49.414  9232  9232 D RemoteCanvas: currentIme: com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME
+04-07 13:29:49.576  9232  9232 I MainConfiguration: onStop called
+04-07 13:29:52.945  9232  9232 I GetTextFragment: newInstance called
+04-07 13:29:52.945  9232  9232 I GetTextFragment: newInstance called
+04-07 13:29:52.949  9232  9232 D PermissionsManager: [android.permission.INTERNET, android.permission.VIBRATE, android.permission.ACCESS_NETWORK_STATE, android.permission.READ_EXTERNAL_STORAGE, android.permission.WRITE_EXTERNAL_STORAGE]
+04-07 13:29:52.958  9232  9232 I MainConfiguration: onStart called
+04-07 13:29:52.966  9232  9232 I MainConfiguration: onResume called
+04-07 13:29:52.967  9232  9232 I MainConfiguration: onResumeFragments called
+04-07 13:29:52.967  9232  9232 I MainConfiguration: arriveOnPage called
+04-07 13:29:53.140  9232  9237 I zygote64: Do partial code cache collection, code=61KB, data=49KB
+04-07 13:29:53.140  9232  9237 I zygote64: After code cache collection, code=61KB, data=49KB
+04-07 13:29:53.140  9232  9237 I zygote64: Increasing code cache capacity to 256KB
+04-07 13:29:53.367  9232  9232 V RfbProto: RFB socket closed
+04-07 13:29:53.368  9232  9232 V RemoteCanvas: Cleaning up resources
+04-07 13:29:56.882  9232  9232 D MainConfiguration: onMenuOpened
+04-07 13:29:56.883  9232  9232 D MainConfiguration: onMenuOpened
+04-07 13:29:56.883  9232  9232 E MainConfiguration: Default Input Mode Item: TOUCHPAD_MODE
+04-07 13:29:56.883  9232  9232 E MainConfiguration: Input Mode Item: TOUCHPAD_MODE
+04-07 13:29:56.883  9232  9232 E MainConfiguration: Input Mode Item: TOUCH_ZOOM_MODE
+04-07 13:29:56.883  9232  9232 E MainConfiguration: Input Mode Item: TOUCH_ZOOM_MODE_DRAG_PAN
+04-07 13:29:56.884  9232  9232 E MainConfiguration: Input Mode Item: SINGLE_HANDED_MODE
+04-07 13:29:57.019  9232  9241 E SpellCheckerSession: ignoring processOrEnqueueTask due to unexpected mState=TASK_CLOSE scp.mWhat=TASK_CLOSE
+04-07 13:29:57.019  9232  9241 I chatty  : uid=10144(com.offsec.nethunter.kex) FinalizerDaemon identical 1 line
+04-07 13:29:57.020  9232  9241 E SpellCheckerSession: ignoring processOrEnqueueTask due to unexpected mState=TASK_CLOSE scp.mWhat=TASK_CLOSE
+04-07 13:30:04.651  9232  9232 I Utils   : Toggled rAltAsIsoL3Shift false
+04-07 13:30:04.975  9232  9249 D OpenGLRenderer: endAllActiveAnimators on 0x704f65d800 (MenuPopupWindow$MenuDropDownListView) with handle 0x704e6738c0
+04-07 13:30:06.117  9232  9232 D MainConfiguration: onMenuOpened
+04-07 13:30:06.118  9232  9232 D MainConfiguration: onMenuOpened
+04-07 13:30:06.119  9232  9232 E MainConfiguration: Default Input Mode Item: TOUCHPAD_MODE
+04-07 13:30:06.119  9232  9232 E MainConfiguration: Input Mode Item: TOUCHPAD_MODE
+04-07 13:30:06.120  9232  9232 E MainConfiguration: Input Mode Item: TOUCH_ZOOM_MODE
+04-07 13:30:06.120  9232  9232 E MainConfiguration: Input Mode Item: TOUCH_ZOOM_MODE_DRAG_PAN
+04-07 13:30:06.120  9232  9232 E MainConfiguration: Input Mode Item: SINGLE_HANDED_MODE
+04-07 13:30:19.596  9232  9232 D PermissionsManager: [android.permission.INTERNET, android.permission.VIBRATE, android.permission.ACCESS_NETWORK_STATE, android.permission.READ_EXTERNAL_STORAGE, android.permission.WRITE_EXTERNAL_STORAGE]
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: I/O error reading configuration
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: java.io.FileNotFoundException: /sdcard/settings.xml (No such file or directory)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.io.FileInputStream.open0(Native Method)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.io.FileInputStream.open(FileInputStream.java:200)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.io.FileInputStream.<init>(FileInputStream.java:150)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.io.FileInputStream.<init>(FileInputStream.java:103)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at com.iiordanov.bVNC.Utils.importSettingsFromXml(Utils.java:273)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at com.iiordanov.bVNC.dialogs.ImportExportDialog$2.onClick(ImportExportDialog.java:113)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.view.View.performClick(View.java:6294)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.view.View$PerformClick.run(View.java:24774)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.os.Handler.handleCallback(Handler.java:790)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.os.Handler.dispatchMessage(Handler.java:99)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.os.Looper.loop(Looper.java:164)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.app.ActivityThread.main(ActivityThread.java:6499)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.lang.reflect.Method.invoke(Native Method)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
+04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
+04-07 13:30:27.419  9232  9232 I MainConfiguration: onPause called
+04-07 13:30:27.660  9232  9232 I RemoteCanvas: Initializing connection to: localhost, port: 1
+04-07 13:30:27.662  9232  9308 I RemoteCanvas: Establishing VNC session to: localhost, port: 5901
+04-07 13:30:27.662  9232  9308 V RfbProto: Connecting to server: localhost at port: 5901
+04-07 13:30:27.662  9232  9232 I InputHandlerGeneric: displayDensity, baseSwipeDist, immersiveSwipeDistance: 2.0 20.0 20.0
+04-07 13:30:27.668  9232  9232 I RemoteCanvasActivity: onResume called.
+04-07 13:30:27.744  9232  9308 W System.err: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:30:27.744  9232  9308 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
+04-07 13:30:27.744  9232  9308 W System.err: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
+04-07 13:30:27.744  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
+04-07 13:30:27.744  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
+04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
+04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
+04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.Socket.connect(Socket.java:616)
+04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.Socket.connect(Socket.java:565)
+04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.Socket.<init>(Socket.java:445)
+04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.Socket.<init>(Socket.java:217)
+04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
+04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
+04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
+04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
+04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
+04-07 13:30:27.746  9232  9308 W System.err: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
+04-07 13:30:27.746  9232  9308 W System.err: 	at libcore.io.Linux.connect(Native Method)
+04-07 13:30:27.746  9232  9308 W System.err: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
+04-07 13:30:27.746  9232  9308 W System.err: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
+04-07 13:30:27.746  9232  9308 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
+04-07 13:30:27.746  9232  9308 W System.err: 	... 14 more
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: java.lang.Exception: Connection to VNC server failed with reason: 
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.Socket.connect(Socket.java:616)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.Socket.connect(Socket.java:565)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.Socket.<init>(Socket.java:445)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.Socket.<init>(Socket.java:217)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.Linux.connect(Native Method)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
+04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	... 14 more
+04-07 13:30:27.747  9232  9308 W System.err: java.lang.Exception: Connection to VNC server failed with reason: 
+04-07 13:30:27.747  9232  9308 W System.err: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:30:27.747  9232  9308 W System.err: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
+04-07 13:30:27.747  9232  9308 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.Socket.connect(Socket.java:616)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.Socket.connect(Socket.java:565)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.Socket.<init>(Socket.java:445)
+04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.Socket.<init>(Socket.java:217)
+04-07 13:30:27.747  9232  9308 W System.err: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
+04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
+04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
+04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
+04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
+04-07 13:30:27.748  9232  9308 W System.err: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
+04-07 13:30:27.748  9232  9308 W System.err: 	at libcore.io.Linux.connect(Native Method)
+04-07 13:30:27.748  9232  9308 W System.err: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
+04-07 13:30:27.748  9232  9308 W System.err: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
+04-07 13:30:27.748  9232  9308 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
+04-07 13:30:27.748  9232  9308 W System.err: 	... 14 more
+04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:475)
+04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
+04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
+04-07 13:30:27.749  9232  9308 V RfbProto: RFB socket closed
+04-07 13:30:27.749  9232  9308 V RemoteCanvas: Cleaning up resources
+04-07 13:30:28.000  9232  9232 D RemoteCanvas: onCreateInputConnection called
+04-07 13:30:28.001  9232  9232 D RemoteCanvas: currentIme: com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME
+04-07 13:30:28.651  9232  9232 I MainConfiguration: onStop called
+04-07 13:30:29.113  9232  9232 I MainConfiguration: onStart called
+04-07 13:30:29.114  9232  9232 I MainConfiguration: onResume called
+04-07 13:30:29.116  9232  9232 I MainConfiguration: onResumeFragments called
+04-07 13:30:29.116  9232  9232 I MainConfiguration: arriveOnPage called
+04-07 13:30:29.507  9232  9232 V RfbProto: RFB socket closed
+04-07 13:30:29.508  9232  9232 V RemoteCanvas: Cleaning up resources


### PR DESCRIPTION
--------- beginning of main
04-07 13:29:40.826  9232  9232 I GetTextFragment: newInstance called
04-07 13:29:40.826  9232  9232 I GetTextFragment: newInstance called
04-07 13:29:40.831  9232  9232 D PermissionsManager: [android.permission.INTERNET, android.permission.VIBRATE, android.permission.ACCESS_NETWORK_STATE, android.permission.READ_EXTERNAL_STORAGE, android.permission.WRITE_EXTERNAL_STORAGE]
04-07 13:29:40.859  9232  9232 W Activity: Can reqeust only one set of permissions at a time
04-07 13:29:40.861  9232  9232 I MainConfiguration: onStart called
04-07 13:29:40.864  9232  9232 I MainConfiguration: onResume called
04-07 13:29:40.865  9232  9232 I MainConfiguration: onResumeFragments called
04-07 13:29:40.868  9232  9232 I MainConfiguration: arriveOnPage called
04-07 13:29:40.948  9232  9249 D OpenGLRenderer: HWUI GL Pipeline
04-07 13:29:40.956  9232  9232 I MainConfiguration: onPause called
04-07 13:29:41.113  9232  9249 I Adreno  : QUALCOMM build                   : bc01238, I8e5c908169
04-07 13:29:41.113  9232  9249 I Adreno  : Build Date                       : 12/22/16
04-07 13:29:41.113  9232  9249 I Adreno  : OpenGL ES Shader Compiler Version: XE031.09.00.03
04-07 13:29:41.113  9232  9249 I Adreno  : Local Branch                     : mybranch24102081
04-07 13:29:41.113  9232  9249 I Adreno  : Remote Branch                    : quic/LA.BR.1.3.6.c1_rb1.5
04-07 13:29:41.113  9232  9249 I Adreno  : Remote Branch                    : NONE
04-07 13:29:41.113  9232  9249 I Adreno  : Reconstruct Branch               : NOTHING
04-07 13:29:41.141  9232  9249 I zygote64: android::hardware::configstore::V1_0::ISurfaceFlingerConfigs::hasWideColorDisplay retrieved: 0
04-07 13:29:41.142  9232  9249 I OpenGLRenderer: Initialized EGL, version 1.4
04-07 13:29:41.142  9232  9249 D OpenGLRenderer: Swap behavior 2
04-07 13:29:41.234  9232  9249 D vndksupport: Loading /vendor/lib64/hw/android.hardware.graphics.mapper@2.0-impl.so from current namespace instead of sphal namespace.
04-07 13:29:42.690  9232  9232 I MainConfiguration: onResume called
04-07 13:29:42.719  9232  9232 I MainConfiguration: onResumeFragments called
04-07 13:29:42.719  9232  9232 I MainConfiguration: arriveOnPage called
04-07 13:29:42.811  9232  9232 W InputMethodManager: Ignoring onBind: cur seq=128, given seq=127
04-07 13:29:48.289  9232  9232 I MainConfiguration: onPause called
04-07 13:29:48.840  9232  9237 I zygote64: Do partial code cache collection, code=30KB, data=29KB
04-07 13:29:48.840  9232  9237 I zygote64: After code cache collection, code=30KB, data=29KB
04-07 13:29:48.840  9232  9237 I zygote64: Increasing code cache capacity to 128KB
04-07 13:29:48.851  9232  9232 I RemoteCanvas: Initializing connection to: localhost, port: 1
04-07 13:29:48.853  9232  9273 I RemoteCanvas: Establishing VNC session to: localhost, port: 5901
04-07 13:29:48.853  9232  9273 V RfbProto: Connecting to server: localhost at port: 5901
04-07 13:29:48.856  9232  9232 I InputHandlerGeneric: displayDensity, baseSwipeDist, immersiveSwipeDistance: 2.0 20.0 20.0
04-07 13:29:48.865  9232  9232 I RemoteCanvasActivity: onResume called.
04-07 13:29:48.870  9232  9232 I Choreographer: Skipped 31 frames!  The application may be doing too much work on its main thread.
04-07 13:29:48.953  9232  9273 W System.err: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
04-07 13:29:48.955  9232  9273 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.Socket.connect(Socket.java:616)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.Socket.connect(Socket.java:565)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.Socket.<init>(Socket.java:445)
04-07 13:29:48.955  9232  9273 W System.err: 	at java.net.Socket.<init>(Socket.java:217)
04-07 13:29:48.955  9232  9273 W System.err: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
04-07 13:29:48.955  9232  9273 W System.err: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
04-07 13:29:48.955  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
04-07 13:29:48.955  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
04-07 13:29:48.956  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
04-07 13:29:48.956  9232  9273 W System.err: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
04-07 13:29:48.956  9232  9273 W System.err: 	at libcore.io.Linux.connect(Native Method)
04-07 13:29:48.956  9232  9273 W System.err: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
04-07 13:29:48.956  9232  9273 W System.err: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
04-07 13:29:48.956  9232  9273 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
04-07 13:29:48.956  9232  9273 W System.err: 	... 14 more
04-07 13:29:48.957  9232  9273 E RemoteCanvas: java.lang.Exception: Connection to VNC server failed with reason: 
04-07 13:29:48.957  9232  9273 E RemoteCanvas: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.Socket.connect(Socket.java:616)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.Socket.connect(Socket.java:565)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.Socket.<init>(Socket.java:445)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at java.net.Socket.<init>(Socket.java:217)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.Linux.connect(Native Method)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
04-07 13:29:48.957  9232  9273 E RemoteCanvas: 	... 14 more
04-07 13:29:48.957  9232  9273 W System.err: java.lang.Exception: Connection to VNC server failed with reason: 
04-07 13:29:48.957  9232  9273 W System.err: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
04-07 13:29:48.957  9232  9273 W System.err: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58107): connect failed: ECONNREFUSED (Connection refused)
04-07 13:29:48.957  9232  9273 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
04-07 13:29:48.957  9232  9273 W System.err: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
04-07 13:29:48.957  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
04-07 13:29:48.957  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.Socket.connect(Socket.java:616)
04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.Socket.connect(Socket.java:565)
04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.Socket.<init>(Socket.java:445)
04-07 13:29:48.958  9232  9273 W System.err: 	at java.net.Socket.<init>(Socket.java:217)
04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
04-07 13:29:48.958  9232  9273 W System.err: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
04-07 13:29:48.958  9232  9273 W System.err: 	at libcore.io.Linux.connect(Native Method)
04-07 13:29:48.958  9232  9273 W System.err: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
04-07 13:29:48.958  9232  9273 W System.err: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
04-07 13:29:48.958  9232  9273 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
04-07 13:29:48.958  9232  9273 W System.err: 	... 14 more
04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:475)
04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
04-07 13:29:48.958  9232  9273 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
04-07 13:29:48.959  9232  9273 V RfbProto: RFB socket closed
04-07 13:29:48.959  9232  9273 V RemoteCanvas: Cleaning up resources
04-07 13:29:49.412  9232  9232 D RemoteCanvas: onCreateInputConnection called
04-07 13:29:49.414  9232  9232 D RemoteCanvas: currentIme: com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME
04-07 13:29:49.576  9232  9232 I MainConfiguration: onStop called
04-07 13:29:52.945  9232  9232 I GetTextFragment: newInstance called
04-07 13:29:52.945  9232  9232 I GetTextFragment: newInstance called
04-07 13:29:52.949  9232  9232 D PermissionsManager: [android.permission.INTERNET, android.permission.VIBRATE, android.permission.ACCESS_NETWORK_STATE, android.permission.READ_EXTERNAL_STORAGE, android.permission.WRITE_EXTERNAL_STORAGE]
04-07 13:29:52.958  9232  9232 I MainConfiguration: onStart called
04-07 13:29:52.966  9232  9232 I MainConfiguration: onResume called
04-07 13:29:52.967  9232  9232 I MainConfiguration: onResumeFragments called
04-07 13:29:52.967  9232  9232 I MainConfiguration: arriveOnPage called
04-07 13:29:53.140  9232  9237 I zygote64: Do partial code cache collection, code=61KB, data=49KB
04-07 13:29:53.140  9232  9237 I zygote64: After code cache collection, code=61KB, data=49KB
04-07 13:29:53.140  9232  9237 I zygote64: Increasing code cache capacity to 256KB
04-07 13:29:53.367  9232  9232 V RfbProto: RFB socket closed
04-07 13:29:53.368  9232  9232 V RemoteCanvas: Cleaning up resources
04-07 13:29:56.882  9232  9232 D MainConfiguration: onMenuOpened
04-07 13:29:56.883  9232  9232 D MainConfiguration: onMenuOpened
04-07 13:29:56.883  9232  9232 E MainConfiguration: Default Input Mode Item: TOUCHPAD_MODE
04-07 13:29:56.883  9232  9232 E MainConfiguration: Input Mode Item: TOUCHPAD_MODE
04-07 13:29:56.883  9232  9232 E MainConfiguration: Input Mode Item: TOUCH_ZOOM_MODE
04-07 13:29:56.883  9232  9232 E MainConfiguration: Input Mode Item: TOUCH_ZOOM_MODE_DRAG_PAN
04-07 13:29:56.884  9232  9232 E MainConfiguration: Input Mode Item: SINGLE_HANDED_MODE
04-07 13:29:57.019  9232  9241 E SpellCheckerSession: ignoring processOrEnqueueTask due to unexpected mState=TASK_CLOSE scp.mWhat=TASK_CLOSE
04-07 13:29:57.019  9232  9241 I chatty  : uid=10144(com.offsec.nethunter.kex) FinalizerDaemon identical 1 line
04-07 13:29:57.020  9232  9241 E SpellCheckerSession: ignoring processOrEnqueueTask due to unexpected mState=TASK_CLOSE scp.mWhat=TASK_CLOSE
04-07 13:30:04.651  9232  9232 I Utils   : Toggled rAltAsIsoL3Shift false
04-07 13:30:04.975  9232  9249 D OpenGLRenderer: endAllActiveAnimators on 0x704f65d800 (MenuPopupWindow$MenuDropDownListView) with handle 0x704e6738c0
04-07 13:30:06.117  9232  9232 D MainConfiguration: onMenuOpened
04-07 13:30:06.118  9232  9232 D MainConfiguration: onMenuOpened
04-07 13:30:06.119  9232  9232 E MainConfiguration: Default Input Mode Item: TOUCHPAD_MODE
04-07 13:30:06.119  9232  9232 E MainConfiguration: Input Mode Item: TOUCHPAD_MODE
04-07 13:30:06.120  9232  9232 E MainConfiguration: Input Mode Item: TOUCH_ZOOM_MODE
04-07 13:30:06.120  9232  9232 E MainConfiguration: Input Mode Item: TOUCH_ZOOM_MODE_DRAG_PAN
04-07 13:30:06.120  9232  9232 E MainConfiguration: Input Mode Item: SINGLE_HANDED_MODE
04-07 13:30:19.596  9232  9232 D PermissionsManager: [android.permission.INTERNET, android.permission.VIBRATE, android.permission.ACCESS_NETWORK_STATE, android.permission.READ_EXTERNAL_STORAGE, android.permission.WRITE_EXTERNAL_STORAGE]
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: I/O error reading configuration
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: java.io.FileNotFoundException: /sdcard/settings.xml (No such file or directory)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.io.FileInputStream.open0(Native Method)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.io.FileInputStream.open(FileInputStream.java:200)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.io.FileInputStream.<init>(FileInputStream.java:150)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.io.FileInputStream.<init>(FileInputStream.java:103)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at com.iiordanov.bVNC.Utils.importSettingsFromXml(Utils.java:273)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at com.iiordanov.bVNC.dialogs.ImportExportDialog$2.onClick(ImportExportDialog.java:113)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.view.View.performClick(View.java:6294)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.view.View$PerformClick.run(View.java:24774)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.os.Handler.handleCallback(Handler.java:790)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.os.Handler.dispatchMessage(Handler.java:99)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.os.Looper.loop(Looper.java:164)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at android.app.ActivityThread.main(ActivityThread.java:6499)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at java.lang.reflect.Method.invoke(Native Method)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
04-07 13:30:22.062  9232  9232 I com.iiordanov.bVNC.ImportExportDialog: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
04-07 13:30:27.419  9232  9232 I MainConfiguration: onPause called
04-07 13:30:27.660  9232  9232 I RemoteCanvas: Initializing connection to: localhost, port: 1
04-07 13:30:27.662  9232  9308 I RemoteCanvas: Establishing VNC session to: localhost, port: 5901
04-07 13:30:27.662  9232  9308 V RfbProto: Connecting to server: localhost at port: 5901
04-07 13:30:27.662  9232  9232 I InputHandlerGeneric: displayDensity, baseSwipeDist, immersiveSwipeDistance: 2.0 20.0 20.0
04-07 13:30:27.668  9232  9232 I RemoteCanvasActivity: onResume called.
04-07 13:30:27.744  9232  9308 W System.err: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
04-07 13:30:27.744  9232  9308 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
04-07 13:30:27.744  9232  9308 W System.err: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
04-07 13:30:27.744  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
04-07 13:30:27.744  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.Socket.connect(Socket.java:616)
04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.Socket.connect(Socket.java:565)
04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.Socket.<init>(Socket.java:445)
04-07 13:30:27.745  9232  9308 W System.err: 	at java.net.Socket.<init>(Socket.java:217)
04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
04-07 13:30:27.745  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
04-07 13:30:27.746  9232  9308 W System.err: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
04-07 13:30:27.746  9232  9308 W System.err: 	at libcore.io.Linux.connect(Native Method)
04-07 13:30:27.746  9232  9308 W System.err: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
04-07 13:30:27.746  9232  9308 W System.err: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
04-07 13:30:27.746  9232  9308 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
04-07 13:30:27.746  9232  9308 W System.err: 	... 14 more
04-07 13:30:27.747  9232  9308 E RemoteCanvas: java.lang.Exception: Connection to VNC server failed with reason: 
04-07 13:30:27.747  9232  9308 E RemoteCanvas: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.Socket.connect(Socket.java:616)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.Socket.connect(Socket.java:565)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.Socket.<init>(Socket.java:445)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at java.net.Socket.<init>(Socket.java:217)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.Linux.connect(Native Method)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
04-07 13:30:27.747  9232  9308 E RemoteCanvas: 	... 14 more
04-07 13:30:27.747  9232  9308 W System.err: java.lang.Exception: Connection to VNC server failed with reason: 
04-07 13:30:27.747  9232  9308 W System.err: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
04-07 13:30:27.747  9232  9308 W System.err: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 5901) from /:: (port 58108): connect failed: ECONNREFUSED (Connection refused)
04-07 13:30:27.747  9232  9308 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:138)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.PlainSocketImpl.socketConnect(PlainSocketImpl.java:129)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:356)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:357)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.Socket.connect(Socket.java:616)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.Socket.connect(Socket.java:565)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.Socket.<init>(Socket.java:445)
04-07 13:30:27.747  9232  9308 W System.err: 	at java.net.Socket.<init>(Socket.java:217)
04-07 13:30:27.747  9232  9308 W System.err: 	at com.iiordanov.bVNC.RfbProto.initSocket(RfbProto.java:354)
04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RfbProto.initializeAndAuthenticate(RfbProto.java:401)
04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:466)
04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
04-07 13:30:27.748  9232  9308 W System.err: Caused by: android.system.ErrnoException: connect failed: ECONNREFUSED (Connection refused)
04-07 13:30:27.748  9232  9308 W System.err: 	at libcore.io.Linux.connect(Native Method)
04-07 13:30:27.748  9232  9308 W System.err: 	at libcore.io.BlockGuardOs.connect(BlockGuardOs.java:126)
04-07 13:30:27.748  9232  9308 W System.err: 	at libcore.io.IoBridge.connectErrno(IoBridge.java:152)
04-07 13:30:27.748  9232  9308 W System.err: 	at libcore.io.IoBridge.connect(IoBridge.java:130)
04-07 13:30:27.748  9232  9308 W System.err: 	... 14 more
04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.startVncConnection(RemoteCanvas.java:475)
04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas.access$200(RemoteCanvas.java:94)
04-07 13:30:27.748  9232  9308 W System.err: 	at com.iiordanov.bVNC.RemoteCanvas$2.run(RemoteCanvas.java:289)
04-07 13:30:27.749  9232  9308 V RfbProto: RFB socket closed
04-07 13:30:27.749  9232  9308 V RemoteCanvas: Cleaning up resources
04-07 13:30:28.000  9232  9232 D RemoteCanvas: onCreateInputConnection called
04-07 13:30:28.001  9232  9232 D RemoteCanvas: currentIme: com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME
04-07 13:30:28.651  9232  9232 I MainConfiguration: onStop called
04-07 13:30:29.113  9232  9232 I MainConfiguration: onStart called
04-07 13:30:29.114  9232  9232 I MainConfiguration: onResume called
04-07 13:30:29.116  9232  9232 I MainConfiguration: onResumeFragments called
04-07 13:30:29.116  9232  9232 I MainConfiguration: arriveOnPage called
04-07 13:30:29.507  9232  9232 V RfbProto: RFB socket closed
04-07 13:30:29.508  9232  9232 V RemoteCanvas: Cleaning up resources